### PR TITLE
Add fork link to about page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
   will_paginate (~> 3.0.6)
-
-BUNDLED WITH
-   1.10.6

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -107,3 +107,5 @@ body {
       display:block !important;
   }
 }
+
+

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,4 +1,6 @@
-<a href="https://github.com/siakaramalegos/recipes-collaboration"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
+<div class="git-banner">
+<a href="https://github.com/siakaramalegos/recipes-collaboration"><img style="position: absolute; top: 50px; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
+</div>
 
 <div class="row">
   <div class="col-md-12">

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,3 +1,5 @@
+<a href="https://github.com/siakaramalegos/recipes-collaboration"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
+
 <div class="row">
   <div class="col-md-12">
     <h1>About TTS Recipe Collection</h1>


### PR DESCRIPTION
Added Git hub fork banner to About page.  Moved the banner 50px from the top.  Resolves Issue #28.
